### PR TITLE
Interface with udev database for various fixes (but future work needed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.url="https://github.com/petersulyok/smfc"
 
 RUN <<EOT
     set -xe
-    apk add --no-cache ipmitool python3 smartmontools
+    apk add --no-cache ipmitool python3 smartmontools py3-udev
     ln -s /usr/sbin/ipmitool /usr/bin/ipmitool
     apk add --no-cache --virtual .depends git build-base linux-headers automake autoconf gettext-dev
     mkdir /tmp/build/

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Here are some sample HWMON file locations for these kernel modules:
  - `drivetemp`: `/sys/class/scsi_disk/0:0:0:0/device/hwmon/hwmon*/temp1_input`
 
 Notes:
-- `smfc` is able to find the proper HWMON file automatically for Intel(R) CPUs and SATA hard drives, but users of the AMD(R) CPU should specify manually (see `hwmon_path=` parameter in the config file)
+- `smfc` is able to find the proper HWMON file automatically for Intel(R) CPUs, AMD(R) CPUs, SATA drives, or NVMe drives, but users may also specify the files manually (see `hwmon_path=` parameter in the config file)
 - Reading `drivetemp` module is the fastest way to get the temperature of the hard disks, and it can read temperature of the SATA hard disks even in standby mode, too. 
 
 ### 10. Installation
@@ -344,6 +344,7 @@ swapped_zones=0
 # Fan controller enabled (bool, default=0)
 enabled=1
 # Number of CPUs (int, default=1)
+# If hwmon_path is not specified (i.e., if CPU detection is automatic), then the value of count is overridden by the detected number of sockets.
 count=1
 # Calculation method for CPU temperatures (int, [0-minimum, 1-average, 2-maximum], default=1)
 temp_calc=1
@@ -361,11 +362,11 @@ max_temp=60.0
 min_level=35
 # Maximum CPU fan level (int, %, default=100)
 max_level=100
-# Path for CPU sys/hwmon file(s) (str multi-line list, default=/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp1_input)
-# It will be automatically generated for Intel CPUs:
+# Path for CPU sys/hwmon file(s) (str multi-line list, default="")
+# It will be automatically generated if not specified:
 # hwmon_path=/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp1_input
 #            /sys/devices/platform/coretemp.1/hwmon/hwmon*/temp1_input
-# and must be specified for AMD CPUs:
+# or
 # hwmon_path=/sys/bus/pci/drivers/k10temp/0000*/hwmon/hwmon*/temp1_input
 
 [HD zone]
@@ -436,7 +437,7 @@ Important notes:
 
 	My experience is that Noctua fans in my box are running stable in the 35-100% fan level interval. An additional user experience is (see [issue #12](https://github.com/petersulyok/smfc/issues/12)) when Noctua fans are paired with Ultra Low Noise Adapter the minimum stable fan level could go up to 45% (i.e. 35% is not stable).  
 
- 3. `[CPU zone] / [HD zone] hwmon_path=`: This parameter is optional for Intel(R) CPUs and SATA drives (i.e. `smfc` can identify automatically the proper file locations), but must be specified manually for AMD(R) CPUs. In case of SAS/SCSI hard disks (where `drivetemp` cannot be loaded) you can specify `hddtemp` value. You can use wild characters (`?,*`) in this parameter and `smfc` will do the path resolution automatically.
+ 3. `[CPU zone] / [HD zone] hwmon_path=`: This parameter is optional for Intel(R) CPUs, AMD(R) CPUs, SATA drives, and NVME drives (i.e., `smfc` can automatically identify the proper file locations), but may also be specified manually for special use cases. In case of SAS/SCSI hard disks (where `drivetemp` cannot be loaded) you can specify `hddtemp` value. You can use wild characters (`?,*`) in this parameter and `smfc` will do the path resolution automatically.
  4. Several sample configuration files are provided for different scenarios in folder `./src/samples`. Please take a look on them, it could be a good starting point in the creation of your own configuration.
 
 ### 12. Automatic execution of the service

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ coverage
 pylint
 pytest
 pytest-cov
+pyudev

--- a/src/smfc.conf
+++ b/src/smfc.conf
@@ -22,6 +22,7 @@ swapped_zones=0
 # Fan controller enabled (bool, default=0)
 enabled=1
 # Number of CPUs (int, default=1)
+# If hwmon_path is not specified (i.e., if CPU detection is automatic), then the value of count is overridden by the detected number of sockets.
 count=1
 # Calculation method for CPU temperatures (int, [0-minimum, 1-average, 2-maximum], default=1)
 temp_calc=1
@@ -39,11 +40,11 @@ max_temp=60.0
 min_level=35
 # Maximum CPU fan level (int, %, default=100)
 max_level=100
-# Path for CPU sys/hwmon file(s) (str multi-line list, default=/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp1_input)
-# It will be automatically generated for Intel CPUs:
+# Path for CPU sys/hwmon file(s) (str multi-line list, default="")
+# It will be automatically generated if not specified:
 # hwmon_path=/sys/devices/platform/coretemp.0/hwmon/hwmon*/temp1_input
 #            /sys/devices/platform/coretemp.1/hwmon/hwmon*/temp1_input
-# and must be specified for AMD CPUs:
+# or
 # hwmon_path=/sys/bus/pci/drivers/k10temp/0000*/hwmon/hwmon*/temp1_input
 
 

--- a/src/smfc.py
+++ b/src/smfc.py
@@ -803,24 +803,9 @@ class HdZone(FanController):
 
                 # If the current one is an NVME SSD disk.
                 # NOTE: kernel provides this, no extra modules required
-                if "nvme-" in self.hd_device_names[i]:
+                if "nvme-" in self.hd_device_names[i] or "ata-" in self.hd_device_names[i] or "-SATA" in self.hd_device_names[i]:
                     block_dev = Devices.from_device_file(self.udev_context, self.hd_device_names[i])
                     self.hwmon_path.append(self.get_tempinput(block_dev.parent))
-
-                # If the current one is a SATA disk.
-                # NOTE: 'drivetemp' kernel module must be loaded otherwise this path does not exist!
-                elif "ata-" in self.hd_device_names[i] or "-SATA" in self.hd_device_names[i]:
-                    disk_name = os.path.basename(os.readlink(self.hd_device_names[i]))
-                    search_str = os.path.join('/sys/class/scsi_disk/*', 'device/block', disk_name)
-                    file_names = glob.glob(search_str)
-                    if not file_names:
-                        raise ValueError(self.ERROR_MSG_FILE_IO.format(search_str))
-                    file_names[0] = file_names[0].replace("/device/block/" + disk_name, "")
-                    search_str = os.path.join(file_names[0], 'device/hwmon/hwmon*/temp1_input')
-                    file_names = glob.glob(search_str)
-                    if not file_names:
-                        raise ValueError(self.ERROR_MSG_FILE_IO.format(search_str))
-                    self.hwmon_path.append(file_names[0])
 
                 # Otherwise we assume it is a SAS/SCSI disk.
                 # 'hddtemp' command will be used to read HD temperature.

--- a/src/smfc.py
+++ b/src/smfc.py
@@ -803,12 +803,8 @@ class HdZone(FanController):
                 # If the current one is an NVME SSD disk.
                 # NOTE: kernel provides this, no extra modules required
                 if "nvme-" in self.hd_device_names[i]:
-                    disk_name = os.path.basename(os.readlink(self.hd_device_names[i]))
-                    search_str = os.path.join('/sys/class/nvme/nvme*', disk_name, 'device/hwmon*/temp1_input')
-                    file_names = glob.glob(search_str)
-                    if not file_names:
-                        raise ValueError(self.ERROR_MSG_FILE_IO.format(search_str))
-                    self.hwmon_path.append(file_names[0])
+                    block_dev = Devices.from_device_file(self.udev_context, self.hd_device_names[i])
+                    self.hwmon_path.append(self.get_tempinput(block_dev.parent))
 
                 # If the current one is a SATA disk.
                 # NOTE: 'drivetemp' kernel module must be loaded otherwise this path does not exist!


### PR DESCRIPTION
Rather than attempting to parse `/dev` and `/sys` directly within smfc, we can outsource that task to `udev` (through [pyudev][1]). This allows us to simplify much of the logic and string parsing, making it less fragile and more robust.

This new strategy gives a convenient fix to petersulyok/smfc#25.

Additionally: under linux (under the persistent storage naming rules present in most distributions AFAIK), the NVMe device by-id symlinks point to the block device (e.g., `/dev/nvme0n1`) rather than the controller (`/dev/nvme0`). However, the corresponding `hwmon` device is actually a child of the controller (thus a sibling to the block device in sysfs).

The original code has a bug where the symlink is assumed to be backwards (so it assumes the link points to `/dev/nvme0` and concatenates the namespace within sysfs). This bug is also present in the unit tests in the test data created by the file `test_00_data.py`. 

Properly parsing the string would require stripping the namespace (in 99% of cases, this is `"n1"`) from the block device name. Instead, in this commit we use pyudev to query the udev database to find the sibling `hwmon` device. Unfortunately, the test file doesn't have such a simple fix, so someone will have to patch it more deeply.

Unfortunately, the unit tests will require a more extensive refactoring to be able to support pyudev, but these changes are not a part of this PR. If we want to keep the current strategy of creating a set of "test data" for the tests, then something like [umockdev][2] might be best. Otherwise, we could write `Mock`s for the expected function calls, but for that a wholesale restructuring of all the test data is probably required.

For now, this code continues to use the `open` and `read` paradigm on sysfs files, but a future refactor might instead use the pythonic interface from pyudev (e.g., `hwmon_dev.attributes.get('temp1_input')`).

[1]: http://pyudev.readthedocs.org/ 
[2]: https://github.com/martinpitt/umockdev