### PR TITLE
Multiple zones support

### DIFF
--- a/src/smfc/constzone.py
+++ b/src/smfc/constzone.py
@@ -25,7 +25,7 @@ class ConstZone(FanController):
     level: int
 
     #pylint: disable=super-init-not-called
-    def __init__(self, log: Log, ipmi: Ipmi, config:ConfigParser) -> None:
+    def __init__(self, log: Log, ipmi: Ipmi, config:ConfigParser, config_section: str, instance_identifier: str) -> None:
         """Initialize the ConstZone class and raise exception in case invalid configuration items.
         Args:
             log (Log): reference to a Log class instance
@@ -38,8 +38,9 @@ class ConstZone(FanController):
         self.log = log
         self.ipmi = ipmi
 
+        self.config_section = config_section
         # Read the list of IPMI zones from a string (trim and remove multiple spaces, convert strings to integers)
-        ipmi_zone_str = config[ConstZone.CS_CONST_ZONE].get(ConstZone.CV_CONST_IPMI_ZONE, fallback=f'{Ipmi.HD_ZONE}')
+        ipmi_zone_str = config[config_section].get(ConstZone.CV_CONST_IPMI_ZONE, fallback=f'{Ipmi.HD_ZONE}')
         ipmi_zone_str = re.sub(' +', ' ', ipmi_zone_str.strip())
         try:
             self.ipmi_zone = [int(s) for s in ipmi_zone_str.split(',' if ',' in ipmi_zone_str else ' ')]
@@ -49,11 +50,11 @@ class ConstZone(FanController):
             if zone not in range(0, 101):
                 raise ValueError(f'invalid value: ipmi_zone={ipmi_zone_str}.')
 
-        self.name = ConstZone.CS_CONST_ZONE
-        self.polling = config[ConstZone.CS_CONST_ZONE].getfloat(ConstZone.CV_CONST_ZONE_POLLING, fallback=30.0)
+        self.name = ConstZone.CS_CONST_ZONE + instance_identifier
+        self.polling = config[config_section].getfloat(ConstZone.CV_CONST_ZONE_POLLING, fallback=30.0)
         if self.polling < 0.0:
             raise ValueError('polling < 0')
-        self.level = config[ConstZone.CS_CONST_ZONE].getint(ConstZone.CV_CONST_ZONE_LEVEL, fallback=50)
+        self.level = config[config_section].getint(ConstZone.CV_CONST_ZONE_LEVEL, fallback=50)
         if self.level not in range(0, 101):
             raise ValueError('invalid level')
         self.last_time = 0.0

--- a/src/smfc/cpuzone.py
+++ b/src/smfc/cpuzone.py
@@ -26,7 +26,7 @@ class CpuZone(FanController):
     CV_CPU_ZONE_MIN_LEVEL: str = 'min_level'
     CV_CPU_ZONE_MAX_LEVEL: str = 'max_level'
 
-    def __init__(self, log: Log, udevc: Context, ipmi: Ipmi, config:ConfigParser) -> None:
+    def __init__(self, log: Log, udevc: Context, ipmi: Ipmi, config:ConfigParser, config_section: str, instance_identifier: str) -> None:
         """Initialize the CpuZone class and raise exception in case of invalid configuration.
         Args:
             log (Log): reference to a Log class instance
@@ -51,19 +51,20 @@ class CpuZone(FanController):
             raise RuntimeError('pyudev: No HWMON device(s) can be found for the CPU.')
         # Calculate count.
         count = len(self.hwmon_path)
+        self.config_section = config_section
 
         # Initialize FanController class.
         super().__init__(log, ipmi,
-            config[CpuZone.CS_CPU_ZONE].get(CpuZone.CV_CPU_IPMI_ZONE, fallback=f'{Ipmi.CPU_ZONE}'),
-            CpuZone.CS_CPU_ZONE, count,
-            config[CpuZone.CS_CPU_ZONE].getint(CpuZone.CV_CPU_ZONE_TEMP_CALC, fallback=FanController.CALC_AVG),
-            config[CpuZone.CS_CPU_ZONE].getint(CpuZone.CV_CPU_ZONE_STEPS, fallback=6),
-            config[CpuZone.CS_CPU_ZONE].getfloat(CpuZone.CV_CPU_ZONE_SENSITIVITY, fallback=3.0),
-            config[CpuZone.CS_CPU_ZONE].getfloat(CpuZone.CV_CPU_ZONE_POLLING, fallback=2),
-            config[CpuZone.CS_CPU_ZONE].getfloat(CpuZone.CV_CPU_ZONE_MIN_TEMP, fallback=30.0),
-            config[CpuZone.CS_CPU_ZONE].getfloat(CpuZone.CV_CPU_ZONE_MAX_TEMP, fallback=60.0),
-            config[CpuZone.CS_CPU_ZONE].getint(CpuZone.CV_CPU_ZONE_MIN_LEVEL, fallback=35),
-            config[CpuZone.CS_CPU_ZONE].getint(CpuZone.CV_CPU_ZONE_MAX_LEVEL, fallback=100)
+            config[config_section].get(CpuZone.CV_CPU_IPMI_ZONE, fallback=f'{Ipmi.CPU_ZONE}'),
+            CpuZone.CS_CPU_ZONE + instance_identifier, count,
+            config[config_section].getint(CpuZone.CV_CPU_ZONE_TEMP_CALC, fallback=FanController.CALC_AVG),
+            config[config_section].getint(CpuZone.CV_CPU_ZONE_STEPS, fallback=6),
+            config[config_section].getfloat(CpuZone.CV_CPU_ZONE_SENSITIVITY, fallback=3.0),
+            config[config_section].getfloat(CpuZone.CV_CPU_ZONE_POLLING, fallback=2),
+            config[config_section].getfloat(CpuZone.CV_CPU_ZONE_MIN_TEMP, fallback=30.0),
+            config[config_section].getfloat(CpuZone.CV_CPU_ZONE_MAX_TEMP, fallback=60.0),
+            config[config_section].getint(CpuZone.CV_CPU_ZONE_MIN_LEVEL, fallback=35),
+            config[config_section].getint(CpuZone.CV_CPU_ZONE_MAX_LEVEL, fallback=100)
         )
 
     def _get_nth_temp(self, index: int) -> float:

--- a/src/smfc/fancontroller.py
+++ b/src/smfc/fancontroller.py
@@ -24,6 +24,7 @@ class FanController:
     log: Log                # Reference to a Log class instance
     ipmi: Ipmi              # Reference to an Ipmi class instance
     ipmi_zone: List[int]    # List of IPMI zones assigned to this fan controller
+    config_section: str     # Name of config section this controller was configured by
     name: str               # Name of the controller
     count: int              # Number of controlled entities
     temp_calc: int          # Calculate of the temperature (0-min, 1-avg, 2-max)

--- a/src/smfc/gpuzone.py
+++ b/src/smfc/gpuzone.py
@@ -37,12 +37,13 @@ class GpuZone(FanController):
     CV_GPU_ZONE_GPU_IDS: str = 'gpu_device_ids'
     CV_GPU_ZONE_NVIDIA_SMI_PATH: str = 'nvidia_smi_path'
 
-    def __init__(self, log: Log, ipmi: Ipmi, config: ConfigParser) -> None:
+    def __init__(self, log: Log, ipmi: Ipmi, config: ConfigParser, config_section: str, instance_identifier: str) -> None:
         """Initialize the GpuZone class. Abort in case of configuration errors.
         Args:
             log (Log): reference to a Log class instance
             ipmi (Ipmi): reference to an Ipmi class instance
             config (configparser.ConfigParser): reference to the configuration (default=None)
+            TODO
         Raises:
             ValueError: invalid parameters
         """
@@ -50,7 +51,7 @@ class GpuZone(FanController):
         count: int          # GPU count.
 
         # Save and validate GpuZone class-specific parameters.
-        gpu_id_list = config[self.CS_GPU_ZONE].get(self.CV_GPU_ZONE_GPU_IDS, '0')
+        gpu_id_list = config[config_section].get(self.CV_GPU_ZONE_GPU_IDS, '0')
         gpu_id_list = re.sub(' +', ' ', gpu_id_list.strip())
         try:
             self.gpu_device_ids = [int(s) for s in gpu_id_list.split(',' if ',' in gpu_id_list else ' ')]
@@ -60,22 +61,24 @@ class GpuZone(FanController):
             if gid not in range(0, 101):
                 raise ValueError(f'invalid value: {self.CV_GPU_ZONE_GPU_IDS}={gpu_id_list}.')
         count = len(self.gpu_device_ids)
-        self.nvidia_smi_path = config[GpuZone.CS_GPU_ZONE].get(GpuZone.CV_GPU_ZONE_NVIDIA_SMI_PATH,
+        self.nvidia_smi_path = config[config_section].get(GpuZone.CV_GPU_ZONE_NVIDIA_SMI_PATH,
                                                               '/usr/bin/nvidia-smi')
         self.nvidia_smi_called = 0
 
+        self.config_section = config_section
+
         # Initialize FanController class.
         super().__init__(log, ipmi,
-            config[GpuZone.CS_GPU_ZONE].get(GpuZone.CV_GPU_IPMI_ZONE, fallback=f'{Ipmi.HD_ZONE}'),
-            GpuZone.CS_GPU_ZONE, count,
-            config[GpuZone.CS_GPU_ZONE].getint(GpuZone.CV_GPU_ZONE_TEMP_CALC, fallback=FanController.CALC_AVG),
-            config[GpuZone.CS_GPU_ZONE].getint(GpuZone.CV_GPU_ZONE_STEPS, fallback=5),
-            config[GpuZone.CS_GPU_ZONE].getfloat(GpuZone.CV_GPU_ZONE_SENSITIVITY, fallback=2),
-            config[GpuZone.CS_GPU_ZONE].getfloat(GpuZone.CV_GPU_ZONE_POLLING, fallback=2),
-            config[GpuZone.CS_GPU_ZONE].getfloat(GpuZone.CV_GPU_ZONE_MIN_TEMP, fallback=40),
-            config[GpuZone.CS_GPU_ZONE].getfloat(GpuZone.CV_GPU_ZONE_MAX_TEMP, fallback=70),
-            config[GpuZone.CS_GPU_ZONE].getint(GpuZone.CV_GPU_ZONE_MIN_LEVEL, fallback=35),
-            config[GpuZone.CS_GPU_ZONE].getint(GpuZone.CV_GPU_ZONE_MAX_LEVEL, fallback=100)
+            config[config_section].get(GpuZone.CV_GPU_IPMI_ZONE, fallback=f'{Ipmi.HD_ZONE}'),
+            GpuZone.CS_GPU_ZONE + instance_identifier, count,
+            config[config_section].getint(GpuZone.CV_GPU_ZONE_TEMP_CALC, fallback=FanController.CALC_AVG),
+            config[config_section].getint(GpuZone.CV_GPU_ZONE_STEPS, fallback=5),
+            config[config_section].getfloat(GpuZone.CV_GPU_ZONE_SENSITIVITY, fallback=2),
+            config[config_section].getfloat(GpuZone.CV_GPU_ZONE_POLLING, fallback=2),
+            config[config_section].getfloat(GpuZone.CV_GPU_ZONE_MIN_TEMP, fallback=40),
+            config[config_section].getfloat(GpuZone.CV_GPU_ZONE_MAX_TEMP, fallback=70),
+            config[config_section].getint(GpuZone.CV_GPU_ZONE_MIN_LEVEL, fallback=35),
+            config[config_section].getint(GpuZone.CV_GPU_ZONE_MAX_LEVEL, fallback=100)
         )
 
         # Print configuration in CONFIG log level (or higher).


### PR DESCRIPTION
This PR adds support for the ability to configure multiple instances of a zone.

As an example, this means you could now (assuming https://github.com/petersulyok/smfc/pull/85):
 * Use the `CPU zone` to configure IPMI zones 0, and 1, with different temp levels and fan levels
 * Use the `CPU zone` to have different fan curves for different temperature ranges
 * Use the `CONST zone` to set a different constant level in each zone

As an example of the first two, the config can look like:

```
[CPU zone]
enabled=1
ipmi_zone=0
temp_calc=1
steps=6
sensitivity=2.0
polling=2
min_temp=40.0
max_temp=60.0
min_level=1
max_level=10

[CPU zone:Extreme temps]
enabled=1
ipmi_zone=0
temp_calc=1
steps=6
sensitivity=3.0
polling=2
min_temp=65.0
max_temp=80.0
min_level=20
max_level=100


[CPU zone:Case fans]
enabled=1
ipmi_zone=1
temp_calc=1
steps=10
sensitivity=5.0
polling=2
min_temp=50.0
max_temp=70.0
min_level=30
max_level=100
```

Which means my CPU fan goes up to 10% at healthy temperatures, then uses much higher percentages if it is getting to dangerous temperatures. Then `Case fans` section controls a different IPMI zone, based on my CPU temperature.