### PR TITLE
Add X10QBi compatibility and a Platform abstraction for platform specific overrides

### DIFF
--- a/config/smfc.conf
+++ b/config/smfc.conf
@@ -15,6 +15,10 @@ fan_mode_delay=10
 fan_level_delay=2
 # IPMI parameters for remote access (string, default='')
 #remote_parameters=-U USERNAME -P PASSWORD -H HOST
+# Optional override to trigger platform specific behaviour (string, default='')
+# This will be automatically discovered from `ipmitool mc info` if not specified,
+# however can be overridden here.
+#platform_name=X10QBi
 
 
 # CPU zone: this fan controller works based on CPU(s) temperature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "smfc"
 description = "Super Micro Fan Control for Linux"
 readme = "README.md"
-version = "4.2.1"
+version = "4.3.0"
 authors = [
     { name = "Peter Sulyok", email = "peter@sulyok.net" }
 ]

--- a/src/smfc/ipmi.py
+++ b/src/smfc/ipmi.py
@@ -6,8 +6,9 @@
 import subprocess
 import time
 from configparser import ConfigParser
-from typing import List
+from typing import List, Dict
 from smfc.log import Log
+from smfc.platform import Platform, FanMode, create_platform
 
 
 class Ipmi:
@@ -19,13 +20,8 @@ class Ipmi:
     fan_level_delay: float      # Delay time after execution of IPMI set fan level function
     remote_parameters: str      # Remote IPMI parameters
     sudo: bool                  # Use `sudo` command for `ipmitool` command
-
-    # Constant values for IPMI fan modes:
-    STANDARD_MODE: int = 0
-    FULL_MODE: int = 1
-    OPTIMAL_MODE: int = 2
-    PUE_MODE: int = 3
-    HEAVY_IO_MODE: int = 4
+    platform_name: str
+    platform: Platform
 
     # Constant values for IPMI fan zones:
     CPU_ZONE: int = 0
@@ -41,6 +37,7 @@ class Ipmi:
     CV_IPMI_FAN_MODE_DELAY: str = 'fan_mode_delay'
     CV_IPMI_FAN_LEVEL_DELAY: str = 'fan_level_delay'
     CV_IPMI_REMOTE_PARAMETERS: str = 'remote_parameters'
+    CV_IPMI_PLATFORM_NAME: str = 'platform_name'
 
     # Timeout value for BMC initialization (seconds).
     BMC_INIT_TIMEOUT: float = 120.0
@@ -63,13 +60,14 @@ class Ipmi:
         self.fan_level_delay = config[Ipmi.CS_IPMI].getint(Ipmi.CV_IPMI_FAN_LEVEL_DELAY, fallback=2)
         self.remote_parameters = config[Ipmi.CS_IPMI].get(Ipmi.CV_IPMI_REMOTE_PARAMETERS, fallback='')
         self.sudo = sudo
+        self.platform_name = config[Ipmi.CS_IPMI].get(Ipmi.CV_IPMI_PLATFORM_NAME, fallback='')
 
         # Validate configuration
         # Check 1: a valid command can be executed successfully and wait if BMC is not ready.
         bmc_timeout = 0.0
         while 1:
             try:
-                self._exec_ipmitool(['sdr'])
+                self.get_sensor_data_repository()
                 break
             except FileNotFoundError as e:
                 raise e
@@ -90,6 +88,7 @@ class Ipmi:
         # Check 3: fan_mode_delay must be positive.
         if self.fan_level_delay < 0:
             raise ValueError(f'Negative fan_level_delay= parameter ({self.fan_level_delay})')
+
         # Print the configuration out at DEBUG log level.
         if self.log.log_level >= Log.LOG_CONFIG:
             self.log.msg(Log.LOG_CONFIG, 'Ipmi module was initialized with:')
@@ -97,6 +96,23 @@ class Ipmi:
             self.log.msg(Log.LOG_CONFIG, f'   {Ipmi.CV_IPMI_FAN_MODE_DELAY} = {self.fan_mode_delay}')
             self.log.msg(Log.LOG_CONFIG, f'   {Ipmi.CV_IPMI_FAN_LEVEL_DELAY} = {self.fan_level_delay}')
             self.log.msg(Log.LOG_CONFIG, f'   {Ipmi.CV_IPMI_REMOTE_PARAMETERS} = {self.remote_parameters}')
+            self.log.msg(Log.LOG_CONFIG, f'   {Ipmi.CV_IPMI_PLATFORM_NAME} = {self.platform_name}')
+
+        # Now that the BMC has been initialised, use it to determine the platform
+        # name if it hasn't been specified by the user
+        if not self.platform_name:
+            self.platform_name = self.identify_platform_name()
+        self.platform = create_platform(self.platform_name)
+        self.log.msg(
+            Log.LOG_DEBUG,
+            (
+                f"Initialised platform '{self.platform.name()}' using "
+                f"'{type(self.platform).__name__}' model."
+            )
+        )
+
+        # Prepare the fans to be controlled manually
+        self.platform.set_fan_manual_mode(self._exec_ipmitool)
 
     def _exec_ipmitool(self, args: List[str]) -> subprocess.CompletedProcess:
         """Execute `ipmitool` command.
@@ -134,25 +150,95 @@ class Ipmi:
             raise e
         return r
 
+    def get_sensor_data_repository(self) -> Dict[str, str]:
+        """Get the sensor data repository. This is equivalent to `ipmitool sdr`.
+        Returns:
+            Dict[str, str]: The value, unit and status of each sensor reported by the system
+        Raises:
+            FileNotFoundError: ipmitool not found
+            RuntimeError: ipmitool execution error
+        """
+        response = self._exec_ipmitool(['sdr'])
+        result = {}
+        for line in response.stdout.splitlines():
+            parts = line.split("|")
+            if len(parts) < 3:
+                # The output is malformed here, return
+                break
+            # The return here always has 3 fields, but the data is not generally well structured
+            # The data may or may not contain a unit, for instance when
+            # the value is hex of the form '0x00'
+            # The data may or may not contain a value, for instance when
+            # a sensor is not connected, it will show "no reading"
+            name = parts[0].strip()
+            status  = parts[2].strip()
+
+            value = 0.00
+            unit = ""
+            if parts[1].strip() == "no reading":
+                unit = parts[1].strip()
+            else:
+                value_unit = parts[1].strip().split(" ")
+                value_str = value_unit[0]
+                unit_str = " ".join(value_unit[1:]).strip()
+                try:
+                    value = float(value_str)
+                    unit = unit_str
+                except ValueError:
+                    try:
+                        value = int(value_str, 16) # value is hex
+                        unit = "bool"
+                    except ValueError:
+                        # If it's not a hex or a float, skip this entry
+                        # so that we don't throw an exception further up
+                        # as this is an unhandled case and we don't want
+                        # to break general compatibility over a parsing
+                        # issue
+                        self.log.msg(
+                            Log.LOG_DEBUG,
+                            f"Failed to parse sdr entry '{parts[1]}'. Skipping."
+                        )
+                        continue
+
+            result[name] = {
+                "value": value,
+                "unit": unit,
+                "status": status,
+            }
+
+        return result
+
+    def identify_platform_name(self) -> str:
+        """Identifies the name of the platform on which smfc is executing. This is
+        extracted from `ipmitool mc info` output.
+        Returns:
+            str: The name of the platform, i.e. 'X10SRi'.
+        Raises:
+            FileNotFoundError: ipmitool not found
+            RuntimeError: ipmitool execution error
+        """
+        response = self._exec_ipmitool(['mc', 'info'])
+        for line in response.stdout.splitlines():
+            if "Product Name" in line:
+                # Will look for a line that matches the following, and extract "X10SRi"
+                # Product Name              : X10SRi
+                platform_name = line.split(":")[1].strip()
+                self.log.msg(Log.LOG_INFO, f"Platform identified as '{platform_name}'")
+                return platform_name
+        # Failed to discover platform name
+        self.log.msg(Log.LOG_INFO, 'Failed to identify platform name')
+        return ""
+
     def get_fan_mode(self) -> int:
         """Get the current IPMI fan mode.
         Returns:
-            int: fan mode (ERROR, STANDARD_MODE, FULL_MODE, OPTIMAL_MODE, HEAVY_IO_MODE)
+            int: fan mode (FanMode.STANDARD, FanMode.FULL, FanMode.OPTIMAL, FanMode.PUE, FanMode.HEAVY_IO)
         Raises:
             FileNotFoundError: ipmitool cannot be found
             RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
             ValueError: output of the ipmitool cannot be interpreted/converted
         """
-        r: subprocess.CompletedProcess  # result of the executed process
-        m: int                          # fan mode
-
-        # Read the current IPMI fan mode.
-        try:
-            r = self._exec_ipmitool(['raw', '0x30', '0x45', '0x00'])
-            m = int(r.stdout)
-        except (RuntimeError, FileNotFoundError) as e:
-            raise e
-        return m
+        return self.platform.get_fan_mode(self._exec_ipmitool)
 
     @staticmethod
     def get_fan_mode_name(mode: int) -> str:
@@ -165,35 +251,28 @@ class Ipmi:
         fan_mode_name: str  # Name of the fan mode
 
         fan_mode_name = 'UNKNOWN'
-        if mode == Ipmi.STANDARD_MODE:
+        if mode == FanMode.STANDARD:
             fan_mode_name = 'STANDARD'
-        elif mode == Ipmi.FULL_MODE:
+        elif mode == FanMode.FULL:
             fan_mode_name = 'FULL'
-        elif mode == Ipmi.OPTIMAL_MODE:
+        elif mode == FanMode.OPTIMAL:
             fan_mode_name = 'OPTIMAL'
-        elif mode == Ipmi.PUE_MODE:
+        elif mode == FanMode.PUE:
             fan_mode_name = 'PUE'
-        elif mode == Ipmi.HEAVY_IO_MODE:
+        elif mode == FanMode.HEAVY_IO:
             fan_mode_name = 'HEAVY IO'
         return fan_mode_name
 
     def set_fan_mode(self, mode: int) -> None:
         """Set the IPMI fan mode.
         Args:
-            mode (int): fan mode (STANDARD_MODE, FULL_MODE, OPTIMAL_MODE, PUE_MODE, HEAVY_IO_MODE)
+            mode (int): fan mode (FanMode.STANDARD, FanMode.FULL, FanMode.OPTIMAL, FanMode.PUE, FanMode.HEAVY_IO)
         Raises:
             ValueError: invalid input parameter
             FileNotFoundError: ipmitool command cannot be found
             RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
         """
-        # Validate mode parameter.
-        if mode not in {self.STANDARD_MODE, self.FULL_MODE, self.OPTIMAL_MODE, self.PUE_MODE, self.HEAVY_IO_MODE}:
-            raise ValueError(f'Invalid fan mode value ({mode}).')
-        # Call ipmitool command and set the new IPMI fan mode.
-        try:
-            self._exec_ipmitool(['raw', '0x30', '0x45', '0x01', f'0x{mode:02x}'])
-        except (RuntimeError, FileNotFoundError) as e:
-            raise e
+        self.platform.set_fan_mode(self._exec_ipmitool, mode)
         # Give time for IPMI system/fans to apply changes in the new fan mode.
         time.sleep(self.fan_mode_delay)
 
@@ -207,17 +286,7 @@ class Ipmi:
             FileNotFoundError: ipmitool command cannot be found
             RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
         """
-        # Validate zone parameter
-        if zone not in range(0, 101):
-            raise ValueError(f'Invalid value: zone ({zone}).')
-        # Validate level parameter (must be in the interval [0..100%])
-        if level not in range(0, 101):
-            raise ValueError(f'Invalid value: level ({level}).')
-        # Set the new IPMI fan level in the specific zone
-        try:
-            self._exec_ipmitool(['raw', '0x30', '0x70', '0x66', '0x01', f'0x{zone:02x}', f'0x{level:02x}'])
-        except (FileNotFoundError, RuntimeError) as e:
-            raise e
+        self.platform.set_fan_level(self._exec_ipmitool, zone, level)
         # Give time for IPMI and fans to spin up/down.
         time.sleep(self.fan_level_delay)
 
@@ -231,19 +300,7 @@ class Ipmi:
             FileNotFoundError: ipmitool command cannot be found
             RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
         """
-        # Validate zone parameters
-        for zone in zone_list:
-            if zone not in range(0, 101):
-                raise ValueError(f'Invalid value: zone ({zone}).')
-        # Validate level parameter (must be in the interval [0..100%])
-        if level not in range(0, 101):
-            raise ValueError(f'Invalid value: level ({level}).')
-        # Set the new IPMI fan level in the specific zone
-        try:
-            for zone in zone_list:
-                self._exec_ipmitool(['raw', '0x30', '0x70', '0x66', '0x01', f'0x{zone:02x}', f'0x{level:02x}'])
-        except (FileNotFoundError, RuntimeError) as e:
-            raise e
+        self.platform.set_multiple_fan_levels(self._exec_ipmitool, zone_list, level)
         # Give time for IPMI and fans to spin up/down.
         time.sleep(self.fan_level_delay)
 
@@ -258,19 +315,7 @@ class Ipmi:
             FileNotFoundError: ipmitool command cannot be found
             RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
         """
-        r: subprocess.CompletedProcess  # result of the executed process
-        level: int                      # Level
-
-        # Validate zone parameter
-        if zone not in range(0, 101):
-            raise ValueError(f'Invalid value: zone ({zone}).')
-        # Get the new IPMI fan level in the specific zone
-        try:
-            r = self._exec_ipmitool(['raw', '0x30', '0x70', '0x66', '0x00', f'0x{zone:x}'])
-            level = int(r.stdout, 16)
-        except (FileNotFoundError, RuntimeError) as e:
-            raise e
-        return level
+        return self.platform.get_fan_level(self._exec_ipmitool, zone)
 
 
 # End.

--- a/src/smfc/platform.py
+++ b/src/smfc/platform.py
@@ -1,0 +1,503 @@
+from abc import ABC, abstractmethod
+from enum import IntEnum
+import subprocess
+from typing import Callable, List
+
+
+def validate_input_range(value: int, valrepr: str, minval: int, maxval: int) -> None:
+    """Throw an error if a value does not lie within the interval specified by
+    [minval, maxval]
+    Args:
+        value (int): The value to validate
+        valrepr (str): A string representation of what the value is
+        minval (int): The minimum inclusive value within the range to test
+        maxval (int): The maximum inclusive value within the range to test
+    Return:
+       None
+    Raises:
+        ValueError: `value` does not lie within `[minval, maxval]`.
+    """
+    if value not in range(minval, maxval + 1):
+        raise ValueError(
+            f"Invalid value: {valrepr} ({value}). "
+            f"Please provide a value within the valid {valrepr} range "
+            f"of [{minval},{maxval}]"
+        )
+
+class FanMode(IntEnum):
+    """The different fan modes supported by Supermicro platforms
+    The integers associated with each of these represent the hex values
+    that need to be propagated to `ipmitool raw` commands to set these modes.
+    """
+    STANDARD = 0
+    FULL = 1
+    OPTIMAL = 2
+    PUE = 3
+    HEAVY_IO = 4
+
+
+class Platform(ABC):
+    """Abstract interface class to represent platforms with different `ipmitool raw`
+    functionality. Concrete derivatives of this class will implement the functionality
+    to make a number of platform-specific queries manipulate fan control.
+    """
+    _name: str
+
+    def __init__(self, name):
+        self._name = name
+
+    # Getters
+    def name(self) -> str:
+        """Get the name of the platform
+        Returns:
+            str: The name of the platform
+        """
+        return self._name
+
+    @abstractmethod
+    def get_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> int:
+        """Get the current IPMI fan mode.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+        Returns:
+            int: fan mode (FanMode.STANDARD, FanMode.FULL, FanMode.OPTIMAL, FanMode.PUE, FanMode.HEAVY_IO)
+        Raises:
+            FileNotFoundError: ipmitool cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+            ValueError: output of the ipmitool cannot be interpreted/converted
+        """
+
+    @abstractmethod
+    def get_fan_level(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], zone: int
+    ) -> int:
+        """Get the current fan level in a specific IPMI zone. Raise an exception in case of invalid parameters.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+            zone (int): fan zone (CPU_ZONE, HD_ZONE)
+        Returns:
+            level (int): fan level in % (0-100)
+        Raises:
+            ValueError: invalid input parameter
+            FileNotFoundError: ipmitool command cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+        """
+
+    # Setters
+    @abstractmethod
+    def set_fan_manual_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> None:
+        """Set the fan controllers on the platform to accept manual PWM or DC input
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+        Raises:
+            FileNotFoundError: ipmitool cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+            ValueError: output of the ipmitool cannot be interpreted/converted
+        """
+
+    @abstractmethod
+    def set_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], mode: int
+    ) -> None:
+        """Set the IPMI fan mode.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+            mode (int): fan mode (FanMode.STANDARD, FanMode.FULL, FanMode.OPTIMAL, FanMode.PUE, FanMode.HEAVY_IO)
+        Raises:
+            ValueError: invalid input parameter
+            FileNotFoundError: ipmitool command cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+        """
+
+    @abstractmethod
+    def set_fan_level(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone: int,
+        level: int,
+    ) -> None:
+        """Set the fan level in the specified IPMI zone. Could raise several exceptions in case of invalid parameters.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+            zone (int): IPMI zone
+            level (int): fan level in % (0-100)
+        Raises:
+            ValueError: invalid input parameter
+            FileNotFoundError: ipmitool command cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+        """
+
+    @abstractmethod
+    def set_multiple_fan_levels(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone_list: List[int],
+        level: int,
+    ) -> None:
+        """Set the fan level in multiple IPMI zones. Could raise several exceptions in case of invalid parameters.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+            zone_list (List[int]): List of IPMI zones
+            level (int): fan level in % (0-100)
+        Raises:
+            ValueError: invalid input parameter
+            FileNotFoundError: ipmitool command cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+        """
+
+
+def create_platform(platform_name: str) -> Platform:
+    """Factory method to create the appropriate Platform object from the platform_name string
+    Args:
+        platform_name (str): The string representing the platform name
+    Returns:
+        Platform: Object providing the low level platform `ipmitool raw` functionality
+            for the specified platform
+    """
+    platform_factory = {
+        "X10QBi": X10QBi,
+    }
+    return platform_factory.get(platform_name, GenericPlatform)(platform_name)
+
+
+class GenericPlatform(Platform):
+    """Class specialisation of Platform to represent the most common `ipmitool raw`
+    functionality of Supermicro X10/X11/X12/X13 motherboards.
+    """
+    valid_fan_modes: List[FanMode] = [
+        FanMode.STANDARD,
+        FanMode.FULL,
+        FanMode.OPTIMAL,
+        FanMode.PUE,
+        FanMode.HEAVY_IO
+    ]
+
+    # Getters
+    def get_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> int:
+        r: subprocess.CompletedProcess  # result of the executed process
+        m: int  # fan mode
+
+        # Read the current IPMI fan mode.
+        try:
+            r = ipmitool_fn(["raw", "0x30", "0x45", "0x00"])
+            m = int(r.stdout)
+        except (RuntimeError, FileNotFoundError) as e:
+            raise e
+        return m
+
+    def get_fan_level(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], zone: int
+    ) -> int:
+        r: subprocess.CompletedProcess  # result of the executed process
+        level: int  # Level
+
+        # Validate zone parameter
+        validate_input_range(zone, "zone", 0, 100)
+        # Get the new IPMI fan level in the specific zone
+        try:
+            r = ipmitool_fn(["raw", "0x30", "0x70", "0x66", "0x00", f"0x{zone:x}"])
+            level = int(r.stdout, 16)
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e
+        return level
+
+    # Setters
+    def set_fan_manual_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> None:
+        pass
+
+    def set_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], mode: int
+    ) -> None:
+        """Set the IPMI fan mode.
+        Args:
+            ipmitool_fn (Callable[[List[str]], subprocess.CompletedProcess]): Function that executes `ipmitool`
+                subprocess
+            mode (int): fan mode (FanMode.STANDARD, FanMode.FULL, FanMode.OPTIMAL, FanMode.PUE, FanMode.HEAVY_IO)
+        Raises:
+            ValueError: invalid input parameter
+            FileNotFoundError: ipmitool command cannot be found
+            RuntimeError: ipmitool execution problem (e.g. non-root user, incompatible IPMI system/motherboard)
+        """
+        # Validate mode parameter.
+        if mode not in self.valid_fan_modes:
+            raise ValueError(f"Invalid value: fan mode ({mode}).")
+        # Call ipmitool command and set the new IPMI fan mode.
+        try:
+            ipmitool_fn(["raw", "0x30", "0x45", "0x01", f"0x{mode:02x}"])
+        except (RuntimeError, FileNotFoundError) as e:
+            raise e
+
+    def set_fan_level(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone: int,
+        level: int,
+    ) -> None:
+        # Validate zone parameter
+        validate_input_range(zone, "zone", 0, 100)
+        # Validate level parameter (must be in the interval [0..100%])
+        validate_input_range(level, "level", 0, 100)
+        # Set the new IPMI fan level in the specific zone
+        try:
+            ipmitool_fn(
+                [
+                    "raw",
+                    "0x30",
+                    "0x70",
+                    "0x66",
+                    "0x01",
+                    f"0x{zone:02x}",
+                    f"0x{level:02x}",
+                ]
+            )
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e
+
+    def set_multiple_fan_levels(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone_list: List[int],
+        level: int,
+    ) -> None:
+        # Validate zone parameter
+        # Validate zone parameters
+        for zone in zone_list:
+            validate_input_range(zone, "zone", 0, 100)
+        # Validate level parameter (must be in the interval [0..100%])
+        validate_input_range(level, "level", 0, 100)
+        # Set the new IPMI fan level in the specific zone
+        try:
+            for zone in zone_list:
+                ipmitool_fn(
+                    [
+                        "raw",
+                        "0x30",
+                        "0x70",
+                        "0x66",
+                        "0x01",
+                        f"0x{zone:02x}",
+                        f"0x{level:02x}",
+                    ]
+                )
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e
+
+
+class X10QBi(Platform):
+    """Class specialisation of Platform to represent the `ipmitool raw` functionality
+    of the Supermicro X10QBi motherboard.
+    """
+    # Constant values for IPMI fan modes:
+    valid_fan_modes: List[FanMode] = [
+        FanMode.STANDARD,
+        FanMode.FULL,
+        FanMode.HEAVY_IO,
+    ]
+    BANK_3_REGISTER: str = "0x03"
+    BANK_4_REGISTER: str = "0x04"
+
+    # Getters
+    def get_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> int:
+        r: subprocess.CompletedProcess  # result of the executed process
+        m: int  # fan mode
+
+        # Read the current IPMI fan mode.
+        try:
+            r = ipmitool_fn(["raw", "0x30", "0x45", "0x00"])
+            m = int(r.stdout)
+        except (RuntimeError, FileNotFoundError) as e:
+            raise e
+        return m
+
+    def get_fan_level(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], zone: int
+    ) -> int:
+        r: subprocess.CompletedProcess  # result of the executed process
+        level: int  # Level
+
+        # Validate zone parameter
+        # Valid zones:
+        # * 0x10: FANCTL1
+        # * 0x11: FANCTL2
+        # * 0x12: FANCTL3
+        # * 0x13: FANCTL4
+        validate_input_range(zone, "zone", int("0x10", 16), int("0x13", 16))
+        # Get the new IPMI fan level in the specific zone
+        try:
+            r = ipmitool_fn(["raw", "0x30", "0x90", "0x5c", "0x03", f"0x{zone:x} 0x01"])
+            level = int(r.stdout, 16)
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e
+        return level
+
+    # Setters
+    def set_fan_manual_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess]
+    ) -> None:
+        # Set Temperature Fan Mapping Relationships (TMFR)
+        # These map which of the 4 fan controllers are assigned to which
+        # of the 10 temperature sensors. Each temperature sensor can have
+        # any of the 4 fan controllers assigned.
+        # Set T1FMR - T10FMR to 0x00 (00000000)
+        # Bits 0-3 contain the settings for FANCTL1-FANCTL4 SMART FAN (F1SF etc).
+        # Set these to 0 to make sure they are not in SmartFan mode
+        # Reference: Nuvoton NCT7904D Datasheet (p114)
+        # https://www.nuvoton.com/export/resource-files/en-us--Nuvoton_NCT7904D_Datasheet_V17.pdf
+        T1FMR_ADDRESS: str = "0x00"  # pylint: disable=C0103
+        T2FMR_ADDRESS: str = "0x01"  # pylint: disable=C0103
+        T3FMR_ADDRESS: str = "0x02"  # pylint: disable=C0103
+        T4FMR_ADDRESS: str = "0x03"  # pylint: disable=C0103
+        T5FMR_ADDRESS: str = "0x00"  # pylint: disable=C0103
+        T6FMR_ADDRESS: str = "0x01"  # pylint: disable=C0103
+        T7FMR_ADDRESS: str = "0x02"  # pylint: disable=C0103
+        T8FMR_ADDRESS: str = "0x03"  # pylint: disable=C0103
+        T9FMR_ADDRESS: str = "0x04"  # pylint: disable=C0103
+        T10FMR_ADDRESS: str = "0x05"  # pylint: disable=C0103
+        tmfr_addresses = [
+            (self.BANK_3_REGISTER, T1FMR_ADDRESS),
+            (self.BANK_3_REGISTER, T2FMR_ADDRESS),
+            (self.BANK_3_REGISTER, T3FMR_ADDRESS),
+            (self.BANK_3_REGISTER, T4FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T5FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T6FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T7FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T8FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T9FMR_ADDRESS),
+            (self.BANK_4_REGISTER, T10FMR_ADDRESS),
+        ]
+        MANUAL_MODE: str = "0x00"  # pylint: disable=C0103
+
+        for register, tmfr_address in tmfr_addresses:
+            ipmitool_fn(
+                [
+                    "raw",
+                    "0x30",
+                    "0x91",
+                    "0x5c",
+                    register,
+                    tmfr_address,
+                    MANUAL_MODE,
+                ]
+            )
+
+        # Set FOMC (FANCTL1-4 Output Mode Control) to PWM output
+        # Bit 3 controls output mode control (0 = set to PWM)
+        # Bits 4-7 control 3Wire-Fan Enable (0 = set to disable)
+        # Reference: Nuvoton NCT7904D Datasheet (p115)
+        # https://www.nuvoton.com/export/resource-files/en-us--Nuvoton_NCT7904D_Datasheet_V17.pdf
+        FOMC_ADDRESS: str = "0x07"  # pylint: disable=C0103
+        PWM_OUTPUT: str = "0x00"  # pylint: disable=C0103
+        ipmitool_fn(
+            [
+                "raw",
+                "0x30",
+                "0x91",
+                "0x5c",
+                self.BANK_3_REGISTER,
+                FOMC_ADDRESS,
+                PWM_OUTPUT,
+            ]
+        )
+
+    def set_fan_mode(
+        self, ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess], mode: int
+    ) -> None:
+        # Validate mode parameter.
+        if mode not in self.valid_fan_modes:
+            raise ValueError(f"Invalid value: fan mode ({mode}).")
+        # Call ipmitool command and set the new IPMI fan mode.
+        try:
+            ipmitool_fn(["raw", "0x30", "0x45", "0x01", f"0x{mode:02x}"])
+        except (RuntimeError, FileNotFoundError) as e:
+            raise e
+
+    def set_fan_level(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone: int,
+        level: int,
+    ) -> None:
+        # Validate zone parameter
+        # Valid zones:
+        # * 0x10: FANCTL1
+        # * 0x11: FANCTL2
+        # * 0x12: FANCTL3
+        # * 0x13: FANCTL4
+        # Reference: Nuvoton NCT7904D Datasheet (p120)
+        # https://www.nuvoton.com/export/resource-files/en-us--Nuvoton_NCT7904D_Datasheet_V17.pdf
+        validate_input_range(zone, "zone", int("0x10", 16), int("0x13", 16))
+        # Validate level parameter (must be in the interval [0..100%])
+        validate_input_range(level, "level", 0, 100)
+
+        # On the X10QBi, 100% is 0xFF (255), not 0x64 (100)
+        normalised_level = level * 255 // 100
+        # Set the new IPMI fan level in the specific zone
+        try:
+            self.set_fan_manual_mode(ipmitool_fn)
+            ipmitool_fn(
+                [
+                    "raw",
+                    "0x30",
+                    "0x91",
+                    "0x5c",
+                    self.BANK_3_REGISTER,
+                    f"0x{zone:02x}",
+                    f"0x{normalised_level:02x}",
+                ]
+            )
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e
+
+    def set_multiple_fan_levels(
+        self,
+        ipmitool_fn: Callable[[List[str]], subprocess.CompletedProcess],
+        zone_list: List[int],
+        level: int,
+    ) -> None:
+        # Validate zone parameters
+        # Valid zones:
+        # * 0x10: FANCTL1
+        # * 0x11: FANCTL2
+        # * 0x12: FANCTL3
+        # * 0x13: FANCTL4
+        # Reference: Nuvoton NCT7904D Datasheet (p120)
+        # https://www.nuvoton.com/export/resource-files/en-us--Nuvoton_NCT7904D_Datasheet_V17.pdf
+        for zone in zone_list:
+            validate_input_range(zone, "zone", int("0x10", 16), int("0x13", 16))
+        # Validate level parameter (must be in the interval [0..100%])
+        validate_input_range(level, "level", 0, 100)
+        # On the X10QBi, 100% is 0xFF (255), not 0x64 (100)
+        normalised_level = level * 255 // 100
+        # Set the new IPMI fan level in the specific zone
+        try:
+            self.set_fan_manual_mode(ipmitool_fn)
+            for zone in zone_list:
+                ipmitool_fn(
+                    [
+                        "raw",
+                        "0x30",
+                        "0x91",
+                        "0x5c",
+                        self.BANK_3_REGISTER,
+                        f"0x{zone:02x}",
+                        f"0x{normalised_level:02x}",
+                    ]
+                )
+        except (FileNotFoundError, RuntimeError) as e:
+            raise e

--- a/test/test_02_ipmi.py
+++ b/test/test_02_ipmi.py
@@ -4,23 +4,121 @@
 #   Unit tests for smfc.Ipmi() class.
 #
 import subprocess
-from typing import Any, List
+import textwrap
 from configparser import ConfigParser
+from typing import Any, List
+
 import pytest
 from mock import MagicMock, call
 from pytest_mock import MockerFixture
-from smfc import Log, Ipmi
+
+from smfc.platform import Platform, GenericPlatform, X10QBi, FanMode
+from smfc import Ipmi, Log
+
 from .test_00_data import TestData
+
+
+def _ipmi_exec_effect(*args):
+    if args == (["sdr"],):
+        return subprocess.CompletedProcess(
+            args=['/usr/bin/ipmitool', 'sdr'],
+            returncode=0,
+            stdout=textwrap.dedent("""\
+                CPU1 Temp        | 33 degrees C      | ok
+                CPU2 Temp        | 31 degrees C      | ok
+                CPU3 Temp        | 29 degrees C      | ok
+                CPU4 Temp        | 34 degrees C      | ok
+                System Temp      | 32 degrees C      | ok
+                Peripheral Temp  | 37 degrees C      | ok
+                PCH Temp         | 52 degrees C      | ok
+                MB_10G Temp      | 66 degrees C      | ok
+                P1M1 DIMMAB Tmp  | no reading        | ns
+                P1M1 DIMMCD Tmp  | no reading        | ns
+                P1M2 DIMMAB Tmp  | 39 degrees C      | ok
+                P1M2 DIMMCD Tmp  | no reading        | ns
+                P2M1 DIMMAB Tmp  | 40 degrees C      | ok
+                P2M1 DIMMCD Tmp  | no reading        | ns
+                P2M2 DIMMAB Tmp  | no reading        | ns
+                P2M2 DIMMCD Tmp  | no reading        | ns
+                P3M1 DIMMAB Tmp  | 40 degrees C      | ok
+                P3M1 DIMMCD Tmp  | no reading        | ns
+                P3M2 DIMMAB Tmp  | no reading        | ns
+                P3M2 DIMMCD Tmp  | no reading        | ns
+                P4M1 DIMMAB Tmp  | 39 degrees C      | ok
+                P4M1 DIMMCD Tmp  | no reading        | ns
+                P4M2 DIMMAB Tmp  | no reading        | ns
+                P4M2 DIMMCD Tmp  | no reading        | ns
+                FAN1             | no reading        | ns
+                FAN2             | 1000 RPM          | ok
+                FAN3             | 1000 RPM          | ok
+                FAN4             | 1000 RPM          | ok
+                FAN5             | no reading        | ns
+                FAN6             | no reading        | ns
+                FAN7             | no reading        | ns
+                FAN8             | no reading        | ns
+                FAN9             | no reading        | ns
+                FAN10            | no reading        | ns
+                Vcpu1            | 1.78 Volts        | ok
+                Vcpu2            | 1.78 Volts        | ok
+                Vcpu3            | 1.79 Volts        | ok
+                Vcpu4            | 1.79 Volts        | ok
+                VMSE_CPU12       | 1.35 Volts        | ok
+                VMSE_CPU34       | 1.35 Volts        | ok
+                1.5VSSB          | 1.50 Volts        | ok
+                VTT              | 0.95 Volts        | ok
+                3.3V             | 3.35 Volts        | ok
+                3.3VSB           | 3.30 Volts        | ok
+                12V              | 12 Volts          | ok
+                VBAT             | 3.11 Volts        | ok
+                Chassis Intru    | 0x01              | ok
+                PS1 Status       | 0x01              | ok
+                PS2 Status       | 0x01              | ok
+                PS3 Status       | invalid entry     | ok
+                """
+            ),
+            stderr='',
+        )
+    if args == (["mc", "info"],):
+        return subprocess.CompletedProcess(
+            args=['/usr/bin/ipmitool', 'mc', 'info'],
+            returncode=0,
+            stdout=textwrap.dedent("""\
+                Device ID                 : 32
+                Device Revision           : 1
+                Firmware Revision         : 3.19
+                IPMI Version              : 2.0
+                Manufacturer ID           : 10876
+                Manufacturer Name         : Super Micro Computer Inc.
+                Product ID                : 1579 (0x062b)
+                Product Name              : X10SRi
+                Device Available          : yes
+                Provides Device SDRs      : no
+                Additional Device Support :
+                    Sensor Device
+                    SDR Repository Device
+                    SEL Device
+                    FRU Inventory Device
+                    IPMB Event Receiver
+                    IPMB Event Generator
+                    Chassis Device
+               """),
+            stderr='',
+        )
+    return subprocess.CompletedProcess([], returncode=0, stdout='') # pragma: no cover
 
 class TestIpmi:
     """Unit test class for smfc.Ipmi() class"""
 
-    @pytest.mark.parametrize("mode_delay, level_delay, remote_pars, sudo, error", [
-        (10, 2, '',                                          False, 'Ipmi.__init__() 1'),
-        (2, 10, '-I lanplus -U ADMIN -P ADMIN -H 127.0.0.1', True,  'Ipmi.__init__() 2')
+    @pytest.mark.parametrize("mode_delay, level_delay, remote_pars, sudo, platform_name, platform_instance, error", [
+        (10, 2, '',False, 'X11SCH-F', GenericPlatform, 'Ipmi.__init__() 1'),
+        (10, 2, '',False, 'X11SCL-iF', GenericPlatform, 'Ipmi.__init__() 2'),
+        (10, 2, '',False, 'X10SRi', GenericPlatform, 'Ipmi.__init__() 3'),
+        (10, 2, '',False, 'generic', GenericPlatform, 'Ipmi.__init__() 4'),
+        (2, 10, '-I lanplus -U ADMIN -P ADMIN -H 127.0.0.1', True, 'X10QBi', X10QBi, 'Ipmi.__init__() 5')
     ])
     def test_init_p1(self, mocker: MockerFixture, mode_delay: int, level_delay: int,
-                     remote_pars: str, sudo: bool, error: str) -> None:
+                     remote_pars: str, sudo: bool, platform_name: str,
+                     platform_instance: Platform, error: str) -> None:
         """Positive unit test function for Ipmi.__init__() method. It contains the following steps:
             - create a shell script for IPMI command
             - mock print() function
@@ -33,14 +131,16 @@ class TestIpmi:
         mock_print = MagicMock()
         mocker.patch('builtins.print', mock_print)
         mock_ipmi_exec = MagicMock()
-        mock_ipmi_exec.return_value = subprocess.CompletedProcess([], returncode=0)
+        mock_ipmi_exec.return_value = subprocess.CompletedProcess([], returncode=0, stdout='')
+
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
         my_config = ConfigParser()
         my_config[Ipmi.CS_IPMI] = {
             Ipmi.CV_IPMI_COMMAND: command,
             Ipmi.CV_IPMI_FAN_MODE_DELAY: str(mode_delay),
             Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(level_delay),
-            Ipmi.CV_IPMI_REMOTE_PARAMETERS: remote_pars
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: remote_pars,
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
         }
         my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
         my_ipmi = Ipmi(my_log, my_config, sudo)
@@ -48,8 +148,11 @@ class TestIpmi:
         assert my_ipmi.fan_mode_delay == mode_delay, error
         assert my_ipmi.fan_level_delay == level_delay, error
         assert my_ipmi.remote_parameters == remote_pars, error
-        assert mock_print.call_count == 5, error  # Ipmi-5
+        assert mock_print.call_count == 7, error  # Ipmi-7
         assert my_ipmi.sudo == sudo, error
+        assert my_ipmi.platform.name() == platform_name
+
+        assert isinstance(my_ipmi.platform, platform_instance)
         del my_td
 
     @pytest.mark.parametrize("case, cmd_exists, mode_delay, level_delay, remote_pars, exception, error", [
@@ -82,7 +185,7 @@ class TestIpmi:
                     raise RuntimeError('ipmitool error (1): error.')
             if case == 5:
                 raise RuntimeError('ipmitool error (1): error.')
-            return subprocess.CompletedProcess([], returncode=0)
+            return subprocess.CompletedProcess([], returncode=0, stdout='')
         #pylint: enable=W0613
 
         def mocked_time_sleep(second: float) -> None:
@@ -192,13 +295,16 @@ class TestIpmi:
         assert cm.type == exception, error
     # pylint: enable=duplicate-code, protected-access
 
-    @pytest.mark.parametrize("expected_mode, error", [
-        (Ipmi.STANDARD_MODE,    'Ipmi.get_fan_mode() 1'),
-        (Ipmi.FULL_MODE,        'Ipmi.get_fan_mode() 2'),
-        (Ipmi.OPTIMAL_MODE,     'Ipmi.get_fan_mode() 3'),
-        (Ipmi.HEAVY_IO_MODE,    'Ipmi.get_fan_mode() 4')
+    @pytest.mark.parametrize("platform_name, expected_mode, error", [
+        ("X11SCH-F", FanMode.STANDARD,    'Ipmi.get_fan_mode() 1'),
+        ("X11SCH-F", FanMode.FULL,        'Ipmi.get_fan_mode() 2'),
+        ("X11SCH-F", FanMode.OPTIMAL,     'Ipmi.get_fan_mode() 3'),
+        ("X11SCH-F", FanMode.HEAVY_IO,    'Ipmi.get_fan_mode() 4'),
+        ("X10QBi",   FanMode.STANDARD,    'Ipmi.get_fan_mode() 5'),
+        ("X10QBi",   FanMode.FULL,        'Ipmi.get_fan_mode() 6'),
+        ("X10QBi",   FanMode.HEAVY_IO,    'Ipmi.get_fan_mode() 7')
     ])
-    def test_get_fan_mode_p1(self, mocker:MockerFixture, expected_mode: int, error: str) -> None:
+    def test_get_fan_mode_p1(self, mocker:MockerFixture, platform_name: str, expected_mode: int, error: str) -> None:
         """Positive unit test for Ipmi.get_fan_mode() method. It contains the following steps:
             - create a shell script with an expected output
             - mock print() function
@@ -212,18 +318,21 @@ class TestIpmi:
         mocker.patch('builtins.print', mock_print)
         my_config = ConfigParser()
         my_config[Ipmi.CS_IPMI] = {
-            Ipmi.CV_IPMI_COMMAND: command
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
         }
         my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
         my_ipmi = Ipmi(my_log, my_config, False)
         assert my_ipmi.get_fan_mode() == expected_mode, error
         del my_td
 
-    @pytest.mark.parametrize("value, exception, error", [
-        ('NA', ValueError, 'Ipmi.get_fan_mode() 5'),
-        ('',   ValueError, 'Ipmi.get_fan_mode() 6')
+    @pytest.mark.parametrize("platform_name, value, exception, error", [
+        ('X11SCH-F', 'NA', ValueError, 'Ipmi.get_fan_mode() 5'),
+        ('X11SCH-F', '',   ValueError, 'Ipmi.get_fan_mode() 6'),
+        ('X10QBi',   'NA', ValueError, 'Ipmi.get_fan_mode() 7'),
+        ('X10QBi',   '',   ValueError, 'Ipmi.get_fan_mode() 8')
     ])
-    def test_get_fan_mode_n1(self, value: str, exception: Any, error: str) -> None:
+    def test_get_fan_mode_n1(self, platform_name: str, value: str, exception: Any, error: str) -> None:
         """Negative unit test for Ipmi.get_fan_mode() method. It contains the following steps:
             - create a shell script providing invalid value
             - initialize a Config, Log, Ipmi classes
@@ -235,7 +344,8 @@ class TestIpmi:
         command = my_td.create_command_file('echo " ' + value + '"')
         my_config = ConfigParser()
         my_config[Ipmi.CS_IPMI] = {
-            Ipmi.CV_IPMI_COMMAND: command
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
         }
         my_log = Log(Log.LOG_ERROR, Log.LOG_STDOUT)
         my_ipmi = Ipmi(my_log, my_config, False)
@@ -245,11 +355,11 @@ class TestIpmi:
         del my_td
 
     @pytest.mark.parametrize("fm, fms, error", [
-        (Ipmi.STANDARD_MODE, 'STANDARD', 'Ipmi.get_fan_mode_name() 1'),
-        (Ipmi.FULL_MODE,     'FULL',     'Ipmi.get_fan_mode_name() 2'),
-        (Ipmi.OPTIMAL_MODE,  'OPTIMAL',  'Ipmi.get_fan_mode_name() 3'),
-        (Ipmi.PUE_MODE,      'PUE',      'Ipmi.get_fan_mode_name() 4'),
-        (Ipmi.HEAVY_IO_MODE, 'HEAVY IO', 'Ipmi.get_fan_mode_name() 5'),
+        (FanMode.STANDARD, 'STANDARD', 'Ipmi.get_fan_mode_name() 1'),
+        (FanMode.FULL,     'FULL',     'Ipmi.get_fan_mode_name() 2'),
+        (FanMode.OPTIMAL,  'OPTIMAL',  'Ipmi.get_fan_mode_name() 3'),
+        (FanMode.PUE,      'PUE',      'Ipmi.get_fan_mode_name() 4'),
+        (FanMode.HEAVY_IO, 'HEAVY IO', 'Ipmi.get_fan_mode_name() 5'),
         (100,                'UNKNOWN',  'Ipmi.get_fan_mode_name() 6')
     ])
     def test_get_fan_mode_name(self, fm: int, fms: str, error: str) -> None:
@@ -262,21 +372,35 @@ class TestIpmi:
         """
         assert Ipmi.get_fan_mode_name(fm) == fms, error
 
-    @pytest.mark.parametrize("fan_mode, error", [
-        (Ipmi.STANDARD_MODE, 'Ipmi.set_fan_mode() 1'),
-        (Ipmi.FULL_MODE,     'Ipmi.set_fan_mode() 2'),
-        (Ipmi.OPTIMAL_MODE,  'Ipmi.set_fan_mode() 3'),
-        (Ipmi.PUE_MODE,      'Ipmi.set_fan_mode() 4'),
-        (Ipmi.HEAVY_IO_MODE, 'Ipmi.set_fan_mode() 5')
+    @pytest.mark.parametrize("platform_name, fan_mode, error", [
+        ('X11SCH-F', FanMode.STANDARD, 'Ipmi.set_fan_mode() 1'),
+        ('X11SCH-F', FanMode.FULL,     'Ipmi.set_fan_mode() 2'),
+        ('X11SCH-F', FanMode.OPTIMAL,  'Ipmi.set_fan_mode() 3'),
+        ('X11SCH-F', FanMode.PUE,      'Ipmi.set_fan_mode() 4'),
+        ('X11SCH-F', FanMode.HEAVY_IO, 'Ipmi.set_fan_mode() 5'),
+        ('X10QBi', FanMode.STANDARD, 'Ipmi.set_fan_mode() 6'),
+        ('X10QBi', FanMode.FULL,     'Ipmi.set_fan_mode() 7'),
+        ('X10QBi', FanMode.HEAVY_IO, 'Ipmi.set_fan_mode() 8'),
     ])
-    def test_set_fan_mode_p1(self, mocker:MockerFixture, fan_mode: int, error: str) -> None:
+    def test_set_fan_mode_p1(self, mocker:MockerFixture, platform_name: str, fan_mode: int, error: str) -> None:
         """Positive unit test for Ipmi.set_fan_mode() method. It contains the following steps:
             - mock Ipmi.exec() and time.sleep() functions
             - create an empty Ipmi class
             - ASSERT: if set_fan_mode() calls Ipmi.exec() and time.sleep() other parameters from expected
             - ASSERT: if set_fan_mode() calls Ipmi.exec() and time.sleep() more from expected times
         """
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_mode_delay = 0
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
@@ -288,11 +412,14 @@ class TestIpmi:
         mock_time_sleep.assert_called_with(my_ipmi.fan_mode_delay)
         assert mock_time_sleep.call_count == 1, error
 
-    @pytest.mark.parametrize("fan_mode, exception, error", [
-        (-1,  ValueError, 'Ipmi.set_fan_mode() 6'),
-        (100, ValueError, 'Ipmi.set_fan_mode() 7')
+    @pytest.mark.parametrize("platform_name, fan_mode, exception, error", [
+        ('X11SCH-F', -1,  ValueError, 'Ipmi.set_fan_mode() 6'),
+        ('X11SCH-F', 100, ValueError, 'Ipmi.set_fan_mode() 7'),
+        ('X10QBi', -1,  ValueError, 'Ipmi.set_fan_mode() 6'),
+        ('X10QBi', 100, ValueError, 'Ipmi.set_fan_mode() 7'),
     ])
-    def test_set_fan_mode_n1(self, mocker: MockerFixture, fan_mode: int, exception: Any, error: str) -> None:
+    def test_set_fan_mode_n1(self, mocker: MockerFixture, platform_name: str,
+                             fan_mode: int, exception: Any, error: str) -> None:
         """Negative unit test for Ipmi.set_fan_mode(). It contains the following steps:
             - mock Ipmi.exec() function
             - create an empty Ipmi class
@@ -301,47 +428,89 @@ class TestIpmi:
         """
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_mode_delay = 0
-        my_ipmi.sudo = False
         with pytest.raises(ValueError) as cm:
             my_ipmi.set_fan_mode(fan_mode)
         assert cm.type == exception, error
 
-    @pytest.mark.parametrize("zone, level, error", [
-        (0, 0,        'Ipmi.set_fan_level() 1'),
-        (0, 50,       'Ipmi.set_fan_level() 2'),
-        (0, 100,      'Ipmi.set_fan_level() 3'),
-        (1, 0,        'Ipmi.set_fan_level() 4'),
-        (1, 50,       'Ipmi.set_fan_level() 5'),
-        (1, 100,      'Ipmi.set_fan_level() 6')
+    @pytest.mark.parametrize("platform_name, zone, level, ipmitool_call_count, error", [
+        ('X11SCH-F', 0, 0, 1,   'Ipmi.set_fan_level() 1'),
+        ('X11SCH-F', 0, 50, 1,  'Ipmi.set_fan_level() 2'),
+        ('X11SCH-F', 0, 100, 1, 'Ipmi.set_fan_level() 3'),
+        ('X11SCH-F', 1, 0, 1,   'Ipmi.set_fan_level() 4'),
+        ('X11SCH-F', 1, 50, 1,  'Ipmi.set_fan_level() 5'),
+        ('X11SCH-F', 1, 100, 1, 'Ipmi.set_fan_level() 6'),
+        ('X10QBi', 16, 0, 12,   'Ipmi.set_fan_level() 7'),
+        ('X10QBi', 16, 50, 12,  'Ipmi.set_fan_level() 8'),
+        ('X10QBi', 17, 100, 12, 'Ipmi.set_fan_level() 9'),
+        ('X10QBi', 18, 0, 12,   'Ipmi.set_fan_level() 10'),
+        ('X10QBi', 19, 50, 12,  'Ipmi.set_fan_level() 11'),
+        ('X10QBi', 19, 100, 12, 'Ipmi.set_fan_level() 12'),
     ])
-    def test_set_fan_level_p1(self, mocker:MockerFixture, zone: int, level: int, error: str) -> None:
+    def test_set_fan_level_p1(self, mocker:MockerFixture, platform_name: str,
+                              zone: int, level: int, ipmitool_call_count: int, error: str) -> None:
         """Positive unit test function. It contains the following steps:
             - mock print(), subprocess.run() functions
             - initialize a Config, Log, Ipmi classes
             - ASSERT: if set_fan_level() calls subprocess.run() command with other parameters than expected
             - delete the instances
         """
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_level_delay = 0
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
         mock_time_sleep = MagicMock()
         mocker.patch('time.sleep', mock_time_sleep)
         my_ipmi.set_fan_level(zone, level)
-        mock_ipmi_exec.assert_called_with(['raw', '0x30', '0x70', '0x66', '0x01', f'0x{zone:02x}', f'0x{level:02x}'])
-        assert mock_ipmi_exec.call_count == 1, error
+        if platform_name == "X10QBi":
+            normalised_level = level * 255 // 100
+            mock_ipmi_exec.assert_called_with(
+                ['raw', '0x30', '0x91', '0x5c', '0x03', f'0x{zone:02x}', f'0x{normalised_level:02x}']
+            )
+        else:
+            mock_ipmi_exec.assert_called_with(
+                ['raw', '0x30', '0x70', '0x66', '0x01', f'0x{zone:02x}', f'0x{level:02x}']
+            )
+        assert mock_ipmi_exec.call_count == ipmitool_call_count, error
         mock_time_sleep.assert_called_with(my_ipmi.fan_level_delay)
         assert mock_time_sleep.call_count == 1, error
 
-    @pytest.mark.parametrize("zone, level, error", [
-        (Ipmi.CPU_ZONE, -1,  'Ipmi.set_fan_level() 7'),
-        (Ipmi.CPU_ZONE, 101, 'Ipmi.set_fan_level() 8'),
-        (-1,            50,  'Ipmi.set_fan_level() 9'),
-        (101,           50,  'Ipmi.set_fan_level() 10')
+    @pytest.mark.parametrize("platform_name, zone, level, error", [
+        ('X11SCH-F', Ipmi.CPU_ZONE, -1,  'Ipmi.set_fan_level() 7'),
+        ('X11SCH-F', Ipmi.CPU_ZONE, 101, 'Ipmi.set_fan_level() 8'),
+        ('X11SCH-F', -1,            50,  'Ipmi.set_fan_level() 9'),
+        ('X11SCH-F', 101,           50,  'Ipmi.set_fan_level() 10'),
+        ('X10QBi', int("0x10", 16), -1,  'Ipmi.set_fan_level() 11'),
+        ('X10QBi', int("0x10", 16), 101, 'Ipmi.set_fan_level() 12'),
+        ('X10QBi', 1,               50,  'Ipmi.set_fan_level() 13'),
+        ('X10QBi', 2,               50,  'Ipmi.set_fan_level() 14'),
+        ('X10QBi', 20,              50,  'Ipmi.set_fan_level() 15'),
     ])
-    def test_set_fan_level_n1(self, mocker: MockerFixture, zone: int, level: int, error: str) -> None:
+    def test_set_fan_level_n1(self, mocker: MockerFixture, platform_name: str,
+                              zone: int, level: int, error: str) -> None:
         """Negative unit test for Ipmi.set_fan_level() method. It contains the following steps:
             - mock Ipmi.exec() function
             - create an empty Ipmi class
@@ -350,26 +519,52 @@ class TestIpmi:
         """
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_level_delay = 0
         my_ipmi.sudo = False
         with pytest.raises(ValueError) as cm:
             my_ipmi.set_fan_level(zone, level)
         assert cm.type is ValueError, error
 
-    @pytest.mark.parametrize("zones, level, error", [
-        ([0],       0,      'Ipmi.set_multiple_fan_levels() 1'),
-        ([0, 1],    50,     'Ipmi.set_multiple_fan_levels() 2'),
-        ([0, 1, 2], 100,    'Ipmi.set_multiple_fan_levels() 3')
+    @pytest.mark.parametrize("platform_name, zones, level, ipmitool_call_count, error", [
+        ('X11SCH-F', [0],              0, 0,      'Ipmi.set_multiple_fan_levels() 1'),
+        ('X11SCH-F', [0, 1],           50, 0,    'Ipmi.set_multiple_fan_levels() 2'),
+        ('X11SCH-F', [0, 1, 2],        100, 0,   'Ipmi.set_multiple_fan_levels() 3'),
+        ('X10QBi',   [16],             0, 11,     'Ipmi.set_multiple_fan_levels() 4'),
+        ('X10QBi',   [16, 17],         50, 11,    'Ipmi.set_multiple_fan_levels() 5'),
+        ('X10QBi',   [16, 17, 18, 19], 100, 11,   'Ipmi.set_multiple_fan_levels() 6'),
     ])
-    def test_set_multiple_fan_levels_p1(self, mocker:MockerFixture, zones: List[int], level: int, error: str) -> None:
+    def test_set_multiple_fan_levels_p1(self, mocker:MockerFixture, platform_name: str,
+                                        zones: List[int], level: int, ipmitool_call_count, error: str) -> None:
         """Positive unit test function. It contains the following steps:
             - mock print(), subprocess.run() functions
             - initialize a Config, Log, Ipmi classes
             - ASSERT: if set_multiple_fan_levels() calls subprocess.run() command with other parameters than expected
             - delete the instances
         """
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_level_delay = 0
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
@@ -378,21 +573,34 @@ class TestIpmi:
         my_ipmi.set_multiple_fan_levels(zones, level)
         calls=[]
         for z in zones:
-            calls.append(call(['raw', '0x30', '0x70', '0x66', '0x01', f'0x{z:02x}', f'0x{level:02x}']))
+            if platform_name == "X10QBi":
+                normalised_level = level * 255 // 100
+                calls.append(call(['raw', '0x30', '0x91', '0x5c', '0x03', f'0x{z:02x}', f'0x{normalised_level:02x}']))
+            else:
+                calls.append(call(['raw', '0x30', '0x70', '0x66', '0x01', f'0x{z:02x}', f'0x{level:02x}']))
         mock_ipmi_exec.assert_has_calls(calls)
-        assert mock_ipmi_exec.call_count == len(zones), error
+        # In this case, ipmitool_call_count refers to the number of non-zone related ipmitool calls
+        # i.e., required to set manual mode
+        assert mock_ipmi_exec.call_count == len(zones) + ipmitool_call_count, error
         mock_time_sleep.assert_called_with(my_ipmi.fan_level_delay)
         assert mock_time_sleep.call_count == 1, error
 
-    @pytest.mark.parametrize("zones, level, error", [
-        ([0],       -1,     'Ipmi.set_multiple_fan_levels() 4'),
-        ([0],       101,    'Ipmi.set_multiple_fan_levels() 5'),
-        ([-1],      50,     'Ipmi.set_multiple_fan_levels() 6'),
-        ([101],     50,     'Ipmi.set_multiple_fan_levels() 7'),
-        ([0, -1],   50,     'Ipmi.set_multiple_fan_levels() 8'),
-        ([101, 0],  50,     'Ipmi.set_multiple_fan_levels() 9')
+    @pytest.mark.parametrize("platform_name, zones, level, error", [
+        ('X11SCH-F', [0],       -1,     'Ipmi.set_multiple_fan_levels() 4'),
+        ('X11SCH-F', [0],       101,    'Ipmi.set_multiple_fan_levels() 5'),
+        ('X11SCH-F', [-1],      50,     'Ipmi.set_multiple_fan_levels() 6'),
+        ('X11SCH-F', [101],     50,     'Ipmi.set_multiple_fan_levels() 7'),
+        ('X11SCH-F', [0, -1],   50,     'Ipmi.set_multiple_fan_levels() 8'),
+        ('X11SCH-F', [101, 0],  50,     'Ipmi.set_multiple_fan_levels() 9'),
+        ('X10QBi',   [16],      -1,     'Ipmi.set_multiple_fan_levels() 10'),
+        ('X10QBi',   [16],      101,    'Ipmi.set_multiple_fan_levels() 11'),
+        ('X10QBi',   [-1],      50,     'Ipmi.set_multiple_fan_levels() 12'),
+        ('X10QBi',   [1],       50,     'Ipmi.set_multiple_fan_levels() 13'),
+        ('X10QBi',   [1, 16],   50,     'Ipmi.set_multiple_fan_levels() 14'),
+        ('X10QBi',   [16, 0],   50,     'Ipmi.set_multiple_fan_levels() 15')
     ])
-    def test_set_multiple_fan_levels_n1(self, mocker: MockerFixture, zones: List[int], level: int, error: str) -> None:
+    def test_set_multiple_fan_levels_n1(self, mocker: MockerFixture, platform_name: str,
+                                        zones: List[int], level: int, error: str) -> None:
         """Negative unit test for Ipmi.set_fan_level() method. It contains the following steps:
             - mock Ipmi.exec() function
             - create an empty Ipmi class
@@ -401,22 +609,40 @@ class TestIpmi:
         """
         mock_ipmi_exec = MagicMock()
         mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_level_delay = 0
         my_ipmi.sudo = False
         with pytest.raises(ValueError) as cm:
             my_ipmi.set_multiple_fan_levels(zones, level)
         assert cm.type is ValueError, error
 
-    @pytest.mark.parametrize("zone, expected_level, error", [
-        (Ipmi.CPU_ZONE, 0,   'Ipmi.get_fan_level() 1'),
-        (Ipmi.CPU_ZONE, 50,  'Ipmi.get_fan_level() 2'),
-        (Ipmi.CPU_ZONE, 100, 'Ipmi.get_fan_level() 3'),
-        (Ipmi.HD_ZONE,  0,   'Ipmi.get_fan_level() 4'),
-        (Ipmi.HD_ZONE,  50,  'Ipmi.get_fan_level() 5'),
-        (Ipmi.HD_ZONE,  100, 'Ipmi.get_fan_level() 6')
+    @pytest.mark.parametrize("platform_name, zone, expected_level, error", [
+        ('X11SCH-F', Ipmi.CPU_ZONE, 0,   'Ipmi.get_fan_level() 1'),
+        ('X11SCH-F', Ipmi.CPU_ZONE, 50,  'Ipmi.get_fan_level() 2'),
+        ('X11SCH-F', Ipmi.CPU_ZONE, 100, 'Ipmi.get_fan_level() 3'),
+        ('X11SCH-F', Ipmi.HD_ZONE,  0,   'Ipmi.get_fan_level() 4'),
+        ('X11SCH-F', Ipmi.HD_ZONE,  50,  'Ipmi.get_fan_level() 5'),
+        ('X11SCH-F', Ipmi.HD_ZONE,  100, 'Ipmi.get_fan_level() 6'),
+        ('X10QBi', 16, 0,   'Ipmi.get_fan_level() 7'),
+        ('X10QBi', 16, 50,  'Ipmi.get_fan_level() 8'),
+        ('X10QBi', 16, 100, 'Ipmi.get_fan_level() 9'),
+        ('X10QBi', 17,  0,   'Ipmi.get_fan_level() 10'),
+        ('X10QBi', 17,  50,  'Ipmi.get_fan_level() 11'),
+        ('X10QBi', 17,  100, 'Ipmi.get_fan_level() 12')
     ])
-    def test_get_fan_level_p1(self, mocker:MockerFixture, zone: int, expected_level: int, error: str) -> None:
+    def test_get_fan_level_p1(self, mocker: MockerFixture, platform_name: str,
+                              zone: int, expected_level: int, error: str) -> None:
         """Positive unit test for Ipmi.get_fan_level() method. It contains the following steps:
             - create a shell script with the expected output
             - mock print() function
@@ -430,22 +656,33 @@ class TestIpmi:
         mocker.patch('builtins.print', mock_print)
         my_config = ConfigParser()
         my_config[Ipmi.CS_IPMI] = {
-            Ipmi.CV_IPMI_COMMAND: command
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
         }
         my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
         my_ipmi = Ipmi(my_log, my_config, False)
         assert my_ipmi.get_fan_level(zone) == expected_level, error
         del my_td
 
-    @pytest.mark.parametrize("zone, level, error", [
-        (Ipmi.CPU_ZONE, 'NA', 'Ipmi.get_fan_level() 7'),
-        (Ipmi.CPU_ZONE, '',   'Ipmi.get_fan_level() 8'),
-        (Ipmi.HD_ZONE,  'NA', 'Ipmi.get_fan_level() 9'),
-        (Ipmi.HD_ZONE,  '',   'Ipmi.get_fan_level() 10'),
-        (-1,            'NA', 'Ipmi.get_fan_level() 11'),
-        (200,           '',   'Ipmi.get_fan_level() 12')
+    @pytest.mark.parametrize("platform_name, zone, level, error", [
+        ('X11SCH-F', Ipmi.CPU_ZONE, 'NA', 'Ipmi.get_fan_level() 7'),
+        ('X11SCH-F', Ipmi.CPU_ZONE, '',   'Ipmi.get_fan_level() 8'),
+        ('X11SCH-F', Ipmi.HD_ZONE,  'NA', 'Ipmi.get_fan_level() 9'),
+        ('X11SCH-F', Ipmi.HD_ZONE,  '',   'Ipmi.get_fan_level() 10'),
+        ('X11SCH-F', -1,            'NA', 'Ipmi.get_fan_level() 11'),
+        ('X11SCH-F', 200,           '',   'Ipmi.get_fan_level() 12'),
+        ('X10QBi', 16, 'NA', 'Ipmi.get_fan_level() 7'),
+        ('X10QBi', 16, '',   'Ipmi.get_fan_level() 8'),
+        ('X10QBi', 17,  'NA', 'Ipmi.get_fan_level() 9'),
+        ('X10QBi', 17,  '',   'Ipmi.get_fan_level() 10'),
+        ('X10QBi', 18,  'NA', 'Ipmi.get_fan_level() 9'),
+        ('X10QBi', 18,  '',   'Ipmi.get_fan_level() 10'),
+        ('X10QBi', 19,  'NA', 'Ipmi.get_fan_level() 9'),
+        ('X10QBi', 19,  '',   'Ipmi.get_fan_level() 10'),
+        ('X10QBi', -1,            'NA', 'Ipmi.get_fan_level() 11'),
+        ('X10QBi', 200,           '',   'Ipmi.get_fan_level() 12'),
     ])
-    def test_get_fan_level_n1(self, zone: int, level: str, error: str) -> None:
+    def test_get_fan_level_n1(self, platform_name: str, zone: int, level: str, error: str) -> None:
         """Negative unit test for Ipmi.get_fan_mode() method. It contains the following steps:
             - create a shell script providing invalid value
             - initialize a Config, Log, Ipmi classes
@@ -457,7 +694,8 @@ class TestIpmi:
         command = my_td.create_command_file('echo " '+level+'"')
         my_config = ConfigParser()
         my_config[Ipmi.CS_IPMI] = {
-            Ipmi.CV_IPMI_COMMAND: command
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
         }
         my_log = Log(Log.LOG_ERROR, Log.LOG_STDOUT)
         my_ipmi = Ipmi(my_log, my_config, False)
@@ -466,11 +704,13 @@ class TestIpmi:
         assert cm.type is ValueError, error
         del my_td
 
-    @pytest.mark.parametrize("exception, error", [
-        (RuntimeError,      'Ipmi exceptions 1'),
-        (FileNotFoundError, 'Ipmi exceptions 2')
+    @pytest.mark.parametrize("platform_name, zone, exception, error", [
+        ('X11SCH-F', Ipmi.CPU_ZONE, RuntimeError,      'Ipmi exceptions 1'),
+        ('X11SCH-F', Ipmi.CPU_ZONE, FileNotFoundError, 'Ipmi exceptions 2'),
+        ('X10QBi',   16,            RuntimeError,      'Ipmi exceptions 3'),
+        ('X10QBi',   16,            FileNotFoundError, 'Ipmi exceptions 4'),
     ])
-    def test_exceptions(self, mocker:MockerFixture, exception: Any, error: str) -> None:
+    def test_exceptions(self, mocker:MockerFixture, platform_name: str, zone: int, exception: Any, error: str) -> None:
         """Negative unit test for Ipmi.get_fan_mode(), Ipmi.set_fan_mode(), Ipmi.set_fan_level(),
            Ipmi.get_fan_level() methods. It contains the following steps:
             - create a shell script providing invalid value
@@ -482,31 +722,107 @@ class TestIpmi:
         def mocked_ipmi_exec(self, args: List[str]) -> subprocess.CompletedProcess:
             raise exception
 
-        mocker.patch('smfc.Ipmi._exec_ipmitool', mocked_ipmi_exec)
-        my_ipmi = Ipmi.__new__(Ipmi)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: platform_name,
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
         my_ipmi.fan_mode_delay = 0
         my_ipmi.fan_level_delay = 0
         my_ipmi.sudo = False
+
+        mocker.patch('smfc.Ipmi._exec_ipmitool', mocked_ipmi_exec)
 
         with pytest.raises(Exception) as cm:
             my_ipmi.get_fan_mode()
         assert cm.type == exception, error
 
         with pytest.raises(Exception) as cm:
-            my_ipmi.set_fan_mode(Ipmi.FULL_MODE)
+            my_ipmi.set_fan_mode(FanMode.FULL)
         assert cm.type == exception, error
 
         with pytest.raises(Exception) as cm:
-            my_ipmi.set_fan_level(Ipmi.CPU_ZONE, 50)
+            my_ipmi.set_fan_level(zone, 50)
         assert cm.type == exception, error
 
         with pytest.raises(Exception) as cm:
-            my_ipmi.set_multiple_fan_levels([0], 50)
+            my_ipmi.set_multiple_fan_levels([zone], 50)
         assert cm.type == exception, error
 
         with pytest.raises(Exception) as cm:
-            my_ipmi.get_fan_level(Ipmi.CPU_ZONE)
+            my_ipmi.get_fan_level(zone)
         assert cm.type == exception, error
 
+    def test_get_sensor_data_repository(self, mocker: MockerFixture) -> None:
+        """Test to confirm that given a realistic return value from `ipmitool sdr`,
+        a well structured dictionary of parsed information is returned.
+        """
+        mock_ipmi_exec = MagicMock()
+        mock_ipmi_exec.side_effect = _ipmi_exec_effect
+        mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: str(""),
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
+
+        sdr = my_ipmi.get_sensor_data_repository()
+
+        assert len(sdr) > 0
+        assert sdr.get("CPU1 Temp").get("value") == 33
+        assert sdr.get("CPU1 Temp").get("unit") == "degrees C"
+        assert sdr.get("CPU1 Temp").get("status") == "ok"
+        assert sdr.get("FAN4").get("value") == 1000
+        assert sdr.get("FAN4").get("unit") == "RPM"
+        assert sdr.get("FAN4").get("status") == "ok"
+        assert sdr.get("FAN5").get("value") == 0
+        assert sdr.get("FAN5").get("unit") == "no reading"
+        assert sdr.get("FAN5").get("status") == "ns"
+        assert sdr.get("Vcpu1").get("value") == 1.78
+        assert sdr.get("Vcpu1").get("unit") == "Volts"
+        assert sdr.get("Vcpu1").get("status") == "ok"
+        assert sdr.get("Chassis Intru").get("value") == 1
+        assert sdr.get("Chassis Intru").get("unit") == "bool"
+        assert sdr.get("Chassis Intru").get("status") == "ok"
+
+
+    def test_identify_platform_name(self, mocker: MockerFixture) -> None:
+        """Test to confirm that given a realistic return value from `ipmitool mc info`,
+        the platform name is successfully extracted and returned as a string.
+        """
+        mock_ipmi_exec = MagicMock()
+        mock_ipmi_exec.side_effect = _ipmi_exec_effect
+        mocker.patch('smfc.Ipmi._exec_ipmitool', mock_ipmi_exec)
+        my_td = TestData()
+        command = my_td.create_command_file()
+        my_config = ConfigParser()
+        my_config[Ipmi.CS_IPMI] = {
+            Ipmi.CV_IPMI_COMMAND: command,
+            Ipmi.CV_IPMI_FAN_MODE_DELAY: str(10),
+            Ipmi.CV_IPMI_FAN_LEVEL_DELAY: str(2),
+            Ipmi.CV_IPMI_REMOTE_PARAMETERS: '',
+            Ipmi.CV_IPMI_PLATFORM_NAME: str(""),
+        }
+        my_log = Log(Log.LOG_DEBUG, Log.LOG_STDOUT)
+        my_ipmi = Ipmi(my_log, my_config, False)
+
+        expected_value = "X10SRi"
+        platform_name = my_ipmi.identify_platform_name()
+
+        assert platform_name == expected_value
 
 # End.


### PR DESCRIPTION
## Overview

I've added compatibility for X10QBi motherboards, confirmed to work with the following configuration:

* Firmware 3.65.00
* BIOS Version: 3.1
* BMC: ASPEED2400
* Redfish Version: 1.0.1
* IPMI Revision: 2.0

Notably, this **may not work on X10QBi boards with BIOS Version: 3.2**, though I don't have the hardware necessary to confirm this.

This also introduces an abstraction that I've titled `Platform` that allows specific implementations of the `ipmitool` commands for boards that don't share compatibility with the existing `ipmitool raw` commands. I think most of the changes required are implemented, including unit testing and coverage. There are still a few things left to do before this is ready for merge, but I wanted to get your eyes on it sooner rather than later.

Still TODO:

- [x] Update README to reflect X10QBi compatibility
- [x] Update README to include X10QBi nuance commentary (like the fact that the valid fan controllers [zones] are referenced with addresses `0x10` (16), `0x11` (17), `0x12` (18) and `0x13` (19), rather than the default assumption at the moment of `zone=0` or `zone=1`)
- [x] Update README to include discussion on setting the new configuration parameter, `[Ipmi.platform_name]`, and it's auto-discovery features if not set.
- [x] Update config/smfc.conf to include `[Ipmi.platform_name]`
- [x] Add log statements where necessary
- [ ] ~~Potentially relocate `test/test_02_ipmi.py::ipmi_exec_effect` to somewhere more appropriate (`test/test_02_data.py`?)~~ deferred pending feedback
- [x] Fixup pylint omissions - docstrings etc
- [x] Move `set_fan_manual_mode()` to be called internally from other `set_*` functions. My observation is that sometimes there are events that must reset these bits in the BMC. This means that `smfc` loses the ability to effect the changes required until the fan controllers are put back into manual mode. It would be more robust for `smfc` to ensure that the fan controllers are in manual mode for every attempt to modify fan pwm.

Any feedback you have is appreciated!

## Summary of changes

* Add Platform abstract interface as the face of a strategy pattern to allow the underlying `ipmitool raw` executions to utilise platform-specific arguments where appropriate.
* Move existing functionality into a `GenericPlatform` subclass of the `Platform` interface, which will be the default behaviour.
* Add `X10QBi` subclass to the `Platform` interface to provide `ipmitool raw` commands specific to this platform.
* Add `Ipmi.platform_name` field to the configuration to allow users to select a platform specialisation. If not specified via the configuration file, smfc will now attempt to automatically discover the platform name and use the appropriate specialisation.
* Expand unit tests to encompass output verification of `ipmitool sdr` and `ipmitool mc info` to confirm that the output is parsed and ingested appropriately.
* Expand unit tests to include the `platform_name` as a parameter for most tests to ensure that both the `Generic` class and `X10QBi` class have coverage and meet expectations around behaviours.
* Refactor fan `*_MODE` variables into a `FanMode` `IntEnum` to avoid code duplication and silence pylint errors.
* Update README with guidance surrounding platform specific overrides to make it clear to the user how these overrides should be used.
* Update `smfc.conf` to include `platform_name` as an optional field to make it easy for users to identify that this is an option.
* Bump version to 4.3.0 to indicate new non-breaking feature.


## Logs

Confirmation of platform type:

```
$ sudo ipmitool mc info
Device ID                 : 32
Device Revision           : 1
Firmware Revision         : 3.65
IPMI Version              : 2.0
Manufacturer ID           : 10876
Manufacturer Name         : Super Micro Computer Inc.
Product ID                : 1830 (0x0726)
Product Name              : X10QBi
Device Available          : yes
Provides Device SDRs      : no

```

Confirmation of working service:

```
$ sudo journalctl -u smfc.service -f
Nov 05 23:03:14 host smfc.service[10675]:    max_level = 100
Nov 05 23:03:14 host smfc.service[10675]:    hwmon_path = ['/sys/devices/platform/coretemp.0/hwmon/hwmon1/temp1_input', '/sys/devices/platform/coretemp.1/hwmon/hwmon2/temp1_input', '/sys/devices/platform/coretemp.2/hwmon/hwmon3/temp1_input', '/sys/devices/platform/coretemp.3/hwmon/hwmon4/temp1_input']
Nov 05 23:03:14 host smfc.service[10675]:    User-defined control function:
Nov 05 23:03:14 host smfc.service[10675]:    0. [T:30.0C - L:35%]
Nov 05 23:03:14 host smfc.service[10675]:    1. [T:36.7C - L:45%]
Nov 05 23:03:14 host smfc.service[10675]:    2. [T:43.3C - L:56%]
Nov 05 23:03:14 host smfc.service[10675]:    3. [T:50.0C - L:67%]
Nov 05 23:03:14 host smfc.service[10675]:    4. [T:56.7C - L:78%]
Nov 05 23:03:14 host smfc.service[10675]:    5. [T:63.3C - L:89%]
Nov 05 23:03:14 host smfc.service[10675]:    6. [T:70.0C - L:100%]
Nov 05 23:03:18 host smfc.service[10675]: CPU zone: new fan level > 46%/39.0C @ IPMI [16] zone(s).
Nov 05 23:11:19 host smfc.service[10675]: CPU zone: new fan level > 35%/33.0C @ IPMI [16] zone(s).
Nov 05 23:12:18 host smfc.service[10675]: CPU zone: new fan level > 46%/36.0C @ IPMI [16] zone(s).
Nov 05 23:14:23 host smfc.service[10675]: CPU zone: new fan level > 35%/33.0C @ IPMI [16] zone(s).
Nov 05 23:15:27 host smfc.service[10675]: CPU zone: new fan level > 46%/36.0C @ IPMI [16] zone(s).
Nov 05 23:18:18 host smfc.service[10675]: CPU zone: new fan level > 35%/33.0C @ IPMI [16] zone(s).
Nov 05 23:19:17 host smfc.service[10675]: CPU zone: new fan level > 46%/36.0C @ IPMI [16] zone(s).
Nov 05 23:22:24 host smfc.service[10675]: CPU zone: new fan level > 35%/33.0C @ IPMI [16] zone(s).
Nov 05 23:24:17 host smfc.service[10675]: CPU zone: new fan level > 46%/36.0C @ IPMI [16] zone(s).
Nov 05 23:28:28 host smfc.service[10675]: CPU zone: new fan level > 35%/33.0C @ IPMI [16] zone(s).
Nov 05 23:30:38 host smfc.service[10675]: CPU zone: new fan level > 46%/36.0C @ IPMI [16] zone(s).
```

I also confirmed visually that fan RPMs were changing appropriately using IPMIView.

Closes #96

